### PR TITLE
Update SECURITY.md with vulnerability reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,21 @@
 # Security review — AI Graph Studio 1.0.0
 
+## Reporting a vulnerability
+
+If you discover a potential security vulnerability in AI Graph Studio, please do not report it through a public GitHub Issue.
+
+Instead, use GitHub's private vulnerability reporting feature for this repository. This allows security reports to be submitted privately to the repository maintainer.
+
+Please include, where possible:
+
+- A clear description of the vulnerability.
+- Steps to reproduce the issue.
+- The affected version or commit.
+- The potential security impact.
+- Any relevant proof of concept or supporting information.
+
+Security reports will be reviewed as soon as reasonably possible. Please avoid publicly disclosing the vulnerability until it has been assessed and, where appropriate, a fix has been made available.
+
 ## Scope and result
 
 Source review plus automated hostile-input checks and real Chrome integration tests. This is not an independent penetration test or certification. No runtime third-party dependencies, analytics, AI APIs, API keys, secrets or arbitrary code execution are present.


### PR DESCRIPTION
## Description

Adds a vulnerability reporting section to `SECURITY.md`, directing security researchers to GitHub Private Vulnerability Reporting instead of public Issues.

This addresses the security disclosure guidance identified during the Codex review of PR #5.

## Type of change

- [x] Documentation

## Related issue

Follow-up to Codex review feedback on PR #5.

## What changed?

- Added a dedicated vulnerability reporting section to `SECURITY.md`.
- Directed vulnerability reports to GitHub Private Vulnerability Reporting.
- Added guidance on the information that should be included in a security report.
- Added responsible disclosure guidance.

## Testing

- [x] Documentation-only change reviewed manually.
- [x] Verified that Private Vulnerability Reporting is enabled for the repository.
